### PR TITLE
(feat: TT-214) Use log rotation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "node-cache": "^5.1.2",
     "node-forge": "^1.3.1",
     "pako": "^2.1.0",
-    "pino": "^8.11.0"
+    "pino": "^8.11.0",
+    "rotating-file-stream": "^3.1.0"
   }
 }

--- a/packages/core/src/commons/logger.ts
+++ b/packages/core/src/commons/logger.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
 import { tmpdir } from 'os';
-import { resolve } from 'path';
+import { createStream } from 'rotating-file-stream';
 
 const defaultLogFileName = `main`;
 let logger: pino.Logger<pino.LoggerOptions>;
@@ -10,8 +10,6 @@ export const initLogger = (
   logName: string = defaultLogFileName,
   logFolder = tmpdir()
 ): void => {
-  const logPath = resolve(logFolder, `ic-http-proxy-${logName}.log`);
-
   logger = pino(
     {
       name,
@@ -21,7 +19,14 @@ export const initLogger = (
       },
     },
     pino.multistream([
-      pino.destination({ sync: false, dest: logPath }),
+      {
+        stream: createStream(`ic-http-proxy-${logName}.log`, {
+          size: '10M',
+          compress: 'gzip',
+          maxFiles: 5,
+          path: logFolder,
+        }),
+      },
       { stream: process.stdout },
     ])
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,7 @@ __metadata:
     pako: ^2.1.0
     pino: ^8.11.0
     prettier: ^2.8.4
+    rotating-file-stream: ^3.1.0
     tsc-alias: ^1.8.5
     typescript: ^4.9.5
   languageName: unknown
@@ -4140,6 +4141,13 @@ __metadata:
     semver-compare: ^1.0.0
     sprintf-js: ^1.1.2
   checksum: 682e28d5491e3ae99728a35ba188f4f0ccb6347dbd492f95dc9f4bfdfe8ee63d8203ad234766ee2db88c8d7a300714304976eb095ce5c9366fe586c03a21586c
+  languageName: node
+  linkType: hard
+
+"rotating-file-stream@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "rotating-file-stream@npm:3.1.0"
+  checksum: 2f5840ae7fee1c93403e042c87f3e90c329244f73d561afb4b3290e3d580c05d971fe72c70177c38fba734172a098b460bfe91b46f77236a2ff4b7b7ed35db18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Log files are automatically rotated so that we don't use too much disk space