### PR TITLE
(fix) Use the initial request header within the agent api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=for-the-badge)](LICENSE)
-[![GitHub license](https://img.shields.io/badge/install-MacOSX-blue.svg?style=for-the-badge&logo=apple)](https://github.com/dfinity/http-proxy/releases/download/0.0.1-alpha/ic-http-proxy-mac-universal-0.0.1-alpha.dmg)
-[![GitHub license](https://img.shields.io/badge/install-Windows-blue.svg?style=for-the-badge&logo=windows)](https://github.com/dfinity/http-proxy/releases/download/0.0.1-alpha/ic-http-proxy-win-x64-0.0.1-alpha.exe)
+[![GitHub license](https://img.shields.io/badge/install-MacOSX-blue.svg?style=for-the-badge&logo=apple)](https://github.com/dfinity/http-proxy/releases/download/0.0.2-alpha/ic-http-proxy-mac-universal-0.0.2-alpha.dmg)
+[![GitHub license](https://img.shields.io/badge/install-Windows-blue.svg?style=for-the-badge&logo=windows)](https://github.com/dfinity/http-proxy/releases/download/0.0.2-alpha/ic-http-proxy-win-x64-0.0.2-alpha.exe)
 
 # IC HTTP Proxy
 > This application is currently only a proof of concept implementation and should be used at your own risk.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "HTTP Proxy to enable trustless access to the Internet Computer.",
   "author": "Kepler Vital <kepler.vital@dfinity.org>",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-core",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Gateway server to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-daemon",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Daemon process to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -59,7 +59,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@dfinity/http-proxy-core": "0.0.1-alpha",
+    "@dfinity/http-proxy-core": "0.0.2-alpha",
     "http-proxy": "^1.18.1",
     "node-cache": "^5.1.2",
     "node-forge": "^1.3.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-server",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Gateway server to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",
@@ -34,6 +34,7 @@
     "yarn": "~3"
   },
   "devDependencies": {
+    "@types/isomorphic-fetch": "^0.0.36",
     "@types/node": "^18.14.0",
     "@types/node-forge": "^1.3.1",
     "@types/pako": "^2.0.0",
@@ -55,6 +56,7 @@
     "@dfinity/principal": "^0.15.6",
     "@dfinity/response-verification": "^0.2.1",
     "http-proxy": "^1.18.1",
+    "isomorphic-fetch": "^3.0.0",
     "node-cache": "^5.1.2",
     "node-forge": "^1.3.1",
     "pako": "^2.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "@dfinity/agent": "^0.15.6",
     "@dfinity/candid": "^0.15.6",
-    "@dfinity/http-proxy-core": "0.0.1-alpha",
-    "@dfinity/http-proxy-daemon": "0.0.1-alpha",
+    "@dfinity/http-proxy-core": "0.0.2-alpha",
+    "@dfinity/http-proxy-daemon": "0.0.2-alpha",
     "@dfinity/principal": "^0.15.6",
     "@dfinity/response-verification": "^0.2.1",
     "http-proxy": "^1.18.1",

--- a/packages/server/src/commons/configs.ts
+++ b/packages/server/src/commons/configs.ts
@@ -3,7 +3,7 @@ import { EnvironmentConfiguration } from './typings';
 
 const environment: EnvironmentConfiguration = {
   platform: os.platform(),
-  userAgent: 'ICHttpProxy/0.0.1',
+  userAgent: 'ICHttpProxy/0.0.2-alpha',
   certificate: {
     storage: {
       folder: 'certs',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-ui",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Desktop interface to facilitate user interaction with the HTTP Proxy server.",
   "main": "built/main.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/dfinity/http-proxy/tree/main/packages/ui#readme",
   "dependencies": {
-    "@dfinity/http-proxy-core": "0.0.1-alpha",
-    "@dfinity/http-proxy-server": "0.0.1-alpha"
+    "@dfinity/http-proxy-core": "0.0.2-alpha",
+    "@dfinity/http-proxy-server": "0.0.2-alpha"
   },
   "devDependencies": {
     "@types/node": "^18.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,7 @@ __metadata:
     "@dfinity/http-proxy-daemon": 0.0.1-alpha
     "@dfinity/principal": ^0.15.6
     "@dfinity/response-verification": ^0.2.1
+    "@types/isomorphic-fetch": ^0.0.36
     "@types/node": ^18.14.0
     "@types/node-forge": ^1.3.1
     "@types/pako": ^2.0.0
@@ -185,6 +186,7 @@ __metadata:
     eslint-config-prettier: ^8.7.0
     eslint-plugin-prettier: ^4.2.1
     http-proxy: ^1.18.1
+    isomorphic-fetch: ^3.0.0
     node-cache: ^5.1.2
     node-forge: ^1.3.1
     nodemon: ^2.0.20
@@ -576,6 +578,13 @@ __metadata:
   version: 4.0.1
   resolution: "@types/http-cache-semantics@npm:4.0.1"
   checksum: 1048aacf627829f0d5f00184e16548205cd9f964bf0841c29b36bc504509230c40bc57c39778703a1c965a6f5b416ae2cbf4c1d4589c889d2838dd9dbfccf6e9
+  languageName: node
+  linkType: hard
+
+"@types/isomorphic-fetch@npm:^0.0.36":
+  version: 0.0.36
+  resolution: "@types/isomorphic-fetch@npm:0.0.36"
+  checksum: 1ffaa1c97a019b1f7a682e2ae31bd4cc3f324198b422c62cece51b42d2750e0dde0c4df2320a52874d6c6019ee4b00ca2e736010d34b206a82e63ef82ef85bbe
   languageName: node
   linkType: hard
 
@@ -2923,6 +2932,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-fetch@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "isomorphic-fetch@npm:3.0.0"
+  dependencies:
+    node-fetch: ^2.6.1
+    whatwg-fetch: ^3.4.1
+  checksum: e5ab79a56ce5af6ddd21265f59312ad9a4bc5a72cebc98b54797b42cb30441d5c5f8d17c5cd84a99e18101c8af6f90c081ecb8d12fd79e332be1778d58486d75
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.5
   resolution: "jake@npm:10.8.5"
@@ -3436,6 +3455,20 @@ __metadata:
   dependencies:
     clone: 2.x
   checksum: b0bdd81a6fee4754fb984a05246b510bb35dc54721116d465899bf4229ee3287fdafb47da526900ee9924fb402ed5c7d8050049d37d8bf2d26dbafc23a2c3205
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.1":
+  version: 2.6.11
+  resolution: "node-fetch@npm:2.6.11"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 249d0666a9497553384d46b5ab296ba223521ac88fed4d8a17d6ee6c2efb0fc890f3e8091cafe7f9fba8151a5b8d925db2671543b3409a56c3cd522b468b47b3
   languageName: node
   linkType: hard
 
@@ -4877,6 +4910,13 @@ __metadata:
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.4.1":
+  version: 3.6.2
+  resolution: "whatwg-fetch@npm:3.6.2"
+  checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,7 +113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dfinity/http-proxy-core@0.0.1-alpha, @dfinity/http-proxy-core@workspace:packages/core":
+"@dfinity/http-proxy-core@0.0.2-alpha, @dfinity/http-proxy-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-core@workspace:packages/core"
   dependencies:
@@ -138,11 +138,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dfinity/http-proxy-daemon@0.0.1-alpha, @dfinity/http-proxy-daemon@workspace:packages/daemon":
+"@dfinity/http-proxy-daemon@0.0.2-alpha, @dfinity/http-proxy-daemon@workspace:packages/daemon":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-daemon@workspace:packages/daemon"
   dependencies:
-    "@dfinity/http-proxy-core": 0.0.1-alpha
+    "@dfinity/http-proxy-core": 0.0.2-alpha
     "@types/node": ^18.14.0
     "@types/node-forge": ^1.3.1
     "@types/pako": ^2.0.0
@@ -166,14 +166,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dfinity/http-proxy-server@0.0.1-alpha, @dfinity/http-proxy-server@workspace:packages/server":
+"@dfinity/http-proxy-server@0.0.2-alpha, @dfinity/http-proxy-server@workspace:packages/server":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-server@workspace:packages/server"
   dependencies:
     "@dfinity/agent": ^0.15.6
     "@dfinity/candid": ^0.15.6
-    "@dfinity/http-proxy-core": 0.0.1-alpha
-    "@dfinity/http-proxy-daemon": 0.0.1-alpha
+    "@dfinity/http-proxy-core": 0.0.2-alpha
+    "@dfinity/http-proxy-daemon": 0.0.2-alpha
     "@dfinity/principal": ^0.15.6
     "@dfinity/response-verification": ^0.2.1
     "@types/isomorphic-fetch": ^0.0.36
@@ -202,8 +202,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-ui@workspace:packages/ui"
   dependencies:
-    "@dfinity/http-proxy-core": 0.0.1-alpha
-    "@dfinity/http-proxy-server": 0.0.1-alpha
+    "@dfinity/http-proxy-core": 0.0.2-alpha
+    "@dfinity/http-proxy-server": 0.0.2-alpha
     "@types/node": ^18.14.0
     "@typescript-eslint/eslint-plugin": ^5.54.1
     "@typescript-eslint/parser": ^5.54.1


### PR DESCRIPTION
agent-js does not maintain the same user agent header as the `http_request` it receives, this change will force it to use the same user agent.