### PR TITLE
(fix: TT-270) Improve proxy resiliency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=for-the-badge)](LICENSE)
-[![GitHub license](https://img.shields.io/badge/install-MacOSX-blue.svg?style=for-the-badge&logo=apple)](https://github.com/dfinity/http-proxy/releases/download/0.0.2-alpha/ic-http-proxy-mac-universal-0.0.2-alpha.dmg)
-[![GitHub license](https://img.shields.io/badge/install-Windows-blue.svg?style=for-the-badge&logo=windows)](https://github.com/dfinity/http-proxy/releases/download/0.0.2-alpha/ic-http-proxy-win-x64-0.0.2-alpha.exe)
+[![GitHub license](https://img.shields.io/badge/install-MacOSX-blue.svg?style=for-the-badge&logo=apple)](https://github.com/dfinity/http-proxy/releases/download/0.0.3-alpha/ic-http-proxy-mac-universal-0.0.3-alpha.dmg)
+[![GitHub license](https://img.shields.io/badge/install-Windows-blue.svg?style=for-the-badge&logo=windows)](https://github.com/dfinity/http-proxy/releases/download/0.0.3-alpha/ic-http-proxy-win-x64-0.0.3-alpha.exe)
 
 # IC HTTP Proxy
 > This application is currently only a proof of concept implementation and should be used at your own risk.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "HTTP Proxy to enable trustless access to the Internet Computer.",
   "author": "Kepler Vital <kepler.vital@dfinity.org>",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-core",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "Gateway server to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-daemon",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "Daemon process to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",
@@ -59,7 +59,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@dfinity/http-proxy-core": "0.0.2-alpha",
+    "@dfinity/http-proxy-core": "0.0.3-alpha",
     "http-proxy": "^1.18.1",
     "node-cache": "^5.1.2",
     "node-forge": "^1.3.1",

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -59,6 +59,7 @@ export class Daemon {
         host: message.host,
         port: message.port,
       },
+      pac: message.pac,
     });
 
     await this.platform.attach();

--- a/packages/daemon/src/platforms/factory.ts
+++ b/packages/daemon/src/platforms/factory.ts
@@ -13,11 +13,13 @@ export class PlatformFactory {
         return new MacPlatform({
           ca: configs.ca,
           proxy: configs.proxy,
+          pac: configs.pac,
         });
       case SupportedPlatforms.Windows:
         return new WindowsPlatform({
           ca: configs.ca,
           proxy: configs.proxy,
+          pac: configs.pac,
         });
       default:
         throw new UnsupportedPlatformError('unknown');

--- a/packages/daemon/src/platforms/mac/mac.ts
+++ b/packages/daemon/src/platforms/mac/mac.ts
@@ -137,7 +137,7 @@ export class MacPlatform implements Platform {
     // toggle web proxy for the active network interface
     if (enable) {
       commands.push(
-        `networksetup -setautoproxyurl "${networkService}" "http://${this.configs.pac.host}:${this.configs.pac.port}"`
+        `networksetup -setautoproxyurl "${networkService}" "http://${this.configs.pac.host}:${this.configs.pac.port}/proxy.pac"`
       );
     }
     commands.push(

--- a/packages/daemon/src/platforms/mac/mac.ts
+++ b/packages/daemon/src/platforms/mac/mac.ts
@@ -2,15 +2,11 @@ import { execAsync, getFile, logger, saveFile } from '@dfinity/http-proxy-core';
 import { exec } from 'child_process';
 import { resolve } from 'path';
 import { Platform } from '../typings';
-import {
-  PlatformConfigs,
-  PlatformProxyInfo,
-  WebProxyConfiguration,
-} from './typings';
+import { PlatformConfigs, PlatformProxyInfo } from './typings';
 import {
   CURL_RC_FILE,
   SHELL_SCRIPT_SEPARATOR,
-  resolveNetworkInfo,
+  getActiveNetworkService,
 } from './utils';
 
 export class MacPlatform implements Platform {
@@ -114,9 +110,8 @@ export class MacPlatform implements Platform {
           encoding: 'utf-8',
         });
 
-        // configure proxy in all network interfaces
-        const networkInfo = await resolveNetworkInfo({ host, port });
-        await this.tooggleNetworkWebProxy(networkInfo, enable);
+        // configure proxy to the active network interface
+        await this.tooggleNetworkWebProxy(enable);
 
         ok();
       } catch (e) {
@@ -126,48 +121,28 @@ export class MacPlatform implements Platform {
     });
   }
 
-  private async tooggleNetworkWebProxy(
-    networkPorts: Map<string, WebProxyConfiguration>,
-    enable: boolean
-  ): Promise<void> {
-    const hasIncorrectStatus = Array.from(networkPorts.values()).some(
-      (proxy) => proxy.http.enabled !== enable || proxy.https.enabled !== enable
-    );
+  private async tooggleNetworkWebProxy(enable: boolean): Promise<void> {
+    const networkService = getActiveNetworkService();
 
-    if (!hasIncorrectStatus) {
-      return;
+    if (!networkService) {
+      throw new Error('no active network service found');
     }
 
+    const status = enable ? 'on' : 'off';
     const commands: string[] = [];
     // enable admin privileges
     commands.push(
       `security authorizationdb write com.apple.trust-settings.admin allow`
     );
-    // set proxy host configuration
-    for (const [port, proxyStatus] of networkPorts.entries()) {
-      if (!proxyStatus.http.enabled) {
-        commands.push(
-          `networksetup -setwebproxy "${port}" ${this.configs.proxy.host} ${this.configs.proxy.port}`
-        );
-      }
-      if (!proxyStatus.https.enabled) {
-        commands.push(
-          `networksetup -setsecurewebproxy "${port}" ${this.configs.proxy.host} ${this.configs.proxy.port}`
-        );
-      }
+    // toggle web proxy for the active network interface
+    if (enable) {
+      commands.push(
+        `networksetup -setautoproxyurl "${networkService}" "http://${this.configs.pac.host}:${this.configs.pac.port}"`
+      );
     }
-    const status = enable ? 'on' : 'off';
-    // toggle web proxy for all network interfaces
-    for (const [port, proxyStatus] of networkPorts.entries()) {
-      if (proxyStatus.http.enabled !== enable) {
-        commands.push(`networksetup -setwebproxystate "${port}" ${status}`);
-      }
-      if (proxyStatus.https.enabled !== enable) {
-        commands.push(
-          `networksetup -setsecurewebproxystate "${port}" ${status}`
-        );
-      }
-    }
+    commands.push(
+      `networksetup -setautoproxystate "${networkService}" ${status}`
+    );
     // remove admin privileges
     commands.push(
       `security authorizationdb remove com.apple.trust-settings.admin`

--- a/packages/daemon/src/platforms/mac/typings.ts
+++ b/packages/daemon/src/platforms/mac/typings.ts
@@ -1,4 +1,4 @@
-import { PlatformRootCA } from '../typings';
+import { PlatformPacInfo, PlatformRootCA } from '../typings';
 
 export interface PlatformProxyInfo {
   host: string;
@@ -8,6 +8,7 @@ export interface PlatformProxyInfo {
 export interface PlatformConfigs {
   ca: PlatformRootCA;
   proxy: PlatformProxyInfo;
+  pac: PlatformPacInfo;
 }
 
 export interface SystemWebProxyInfo {

--- a/packages/daemon/src/platforms/mac/utils.ts
+++ b/packages/daemon/src/platforms/mac/utils.ts
@@ -1,92 +1,25 @@
-import { exec } from 'child_process';
-import { WebProxyConfiguration } from './typings';
-import { PlatformProxyInfo } from '../typings';
+import { execSync } from 'child_process';
 
 export const SHELL_SCRIPT_SEPARATOR = ' ; ';
 export const CURL_RC_FILE = '.curlrc';
 export const PROXY_GET_SEPARATOR = ':ic-separator:';
 
-export const resolveNetworkInfo = async (
-  proxy: PlatformProxyInfo
-): Promise<Map<string, WebProxyConfiguration>> => {
-  const ports = await fetchHardwarePorts();
-  const networkInfo = new Map<string, WebProxyConfiguration>();
-  for (const port of ports) {
-    const webProxyState = await fetchNetworkWebProxy(port, proxy);
-    networkInfo.set(port, webProxyState);
+export const getActiveNetworkService = (): string | null => {
+  const networkServices = execSync(
+    `networksetup -listallnetworkservices | tail -n +2`
+  )
+    .toString()
+    .split('\n');
+  for (const networkService of networkServices) {
+    const assignedIpAddress = execSync(
+      `networksetup -getinfo "${networkService}" | awk '/^IP address:/{print $3}'`
+    )
+      .toString()
+      .trim();
+    if (assignedIpAddress.length > 0) {
+      return networkService;
+    }
   }
 
-  return networkInfo;
-};
-
-export const fetchHardwarePorts = async (): Promise<string[]> => {
-  return new Promise<string[]>((ok, err) => {
-    exec(
-      `networksetup -listnetworkserviceorder | grep 'Hardware Port'`,
-      (error, stdout) => {
-        if (error) {
-          return err(error);
-        }
-
-        const ports = stdout
-          .split('\n')
-          .map((line) => {
-            const [, port] =
-              line.match(new RegExp(/Hardware Port:\s(.*),.*/)) ?? [];
-
-            return port;
-          })
-          .filter((port) => !!port) as string[];
-
-        ok(ports);
-      }
-    );
-  });
-};
-
-export const fetchNetworkWebProxy = async (
-  networkHardwarePort = 'wi-fi',
-  proxy: PlatformProxyInfo
-): Promise<WebProxyConfiguration> => {
-  return new Promise<WebProxyConfiguration>(async (ok, err) => {
-    const shellScript =
-      `networksetup -getwebproxy "${networkHardwarePort}"` +
-      SHELL_SCRIPT_SEPARATOR +
-      `echo "${PROXY_GET_SEPARATOR}"` +
-      SHELL_SCRIPT_SEPARATOR +
-      `networksetup -getsecurewebproxy "${networkHardwarePort}"`;
-
-    exec(`${shellScript}`, (error, stdout) => {
-      if (error) {
-        return err(error);
-      }
-
-      const [rawHttpProxy, rawHttpsProxy] = stdout.split(PROXY_GET_SEPARATOR);
-
-      const isEnabled = (parts: string[]): boolean => {
-        const sameProxyHost = parts.some((part) => {
-          const [, host] =
-            part.trim().match(new RegExp(/^Server:\s+(.*)/)) ?? [];
-          return host ? host === proxy.host : false;
-        });
-        const sameProxyPort = parts.some((part) => {
-          const [, port] = part.trim().match(new RegExp(/^Port:\s+(.*)/)) ?? [];
-          return port ? Number(port) === proxy.port : false;
-        });
-        const isEnabled = parts.some((part) => {
-          const [, enabled] =
-            part.trim().match(new RegExp(/^Enabled:\s+(.*)/)) ?? [];
-
-          return enabled ? enabled.toLowerCase() === 'yes' : false;
-        });
-
-        return sameProxyHost && sameProxyPort && isEnabled;
-      };
-
-      ok({
-        http: { enabled: isEnabled(rawHttpProxy.split('\n')) },
-        https: { enabled: isEnabled(rawHttpsProxy.split('\n')) },
-      });
-    });
-  });
+  return null;
 };

--- a/packages/daemon/src/platforms/typings.ts
+++ b/packages/daemon/src/platforms/typings.ts
@@ -13,8 +13,11 @@ export interface PlatformProxyInfo {
   port: number;
 }
 
+export type PlatformPacInfo = PlatformProxyInfo;
+
 export interface PlatformBuildConfigs {
   platform: string;
   ca: PlatformRootCA;
   proxy: PlatformProxyInfo;
+  pac: PlatformPacInfo;
 }

--- a/packages/daemon/src/platforms/utils.ts
+++ b/packages/daemon/src/platforms/utils.ts
@@ -1,0 +1,14 @@
+export const PAC_FILE_NAME = 'ic-proxy.pac';
+
+export const getProxyAutoConfiguration = (
+  proxyHost: string,
+  proxyPort: number
+): string => {
+  return `function FindProxyForURL(url, host) {
+    if (url.startsWith("https:") || url.startsWith("http:")) {
+      return "PROXY ${proxyHost}:${proxyPort}; DIRECT";
+    }
+
+    return "DIRECT";
+  }`;
+};

--- a/packages/daemon/src/platforms/windows/typings.ts
+++ b/packages/daemon/src/platforms/windows/typings.ts
@@ -1,4 +1,4 @@
-import { PlatformRootCA } from '../typings';
+import { PlatformPacInfo, PlatformRootCA } from '../typings';
 
 export interface PlatformProxyInfo {
   host: string;
@@ -8,6 +8,7 @@ export interface PlatformProxyInfo {
 export interface PlatformConfigs {
   ca: PlatformRootCA;
   proxy: PlatformProxyInfo;
+  pac: PlatformPacInfo;
 }
 
 export interface SystemWebProxyInfo {

--- a/packages/daemon/src/platforms/windows/windows.ts
+++ b/packages/daemon/src/platforms/windows/windows.ts
@@ -20,8 +20,8 @@ export class WindowsPlatform implements Platform {
       this.configs.ca.commonName
     );
     await this.configureWebProxy(true, {
-      host: this.configs.proxy.host,
-      port: this.configs.proxy.port,
+      host: this.configs.pac.host,
+      port: this.configs.pac.port,
     });
   }
 
@@ -39,8 +39,8 @@ export class WindowsPlatform implements Platform {
       this.configs.ca.commonName
     );
     await this.configureWebProxy(false, {
-      host: this.configs.proxy.host,
-      port: this.configs.proxy.port,
+      host: this.configs.pac.host,
+      port: this.configs.pac.port,
     });
   }
 
@@ -74,8 +74,8 @@ export class WindowsPlatform implements Platform {
     return new Promise<void>(async (ok, err) => {
       try {
         const updateInternetSettingsProxy = enable
-          ? `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name ProxyServer -Value 'http://${host}:${port}'"`
-          : `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name ProxyServer -Value ''"`;
+          ? `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name AutoConfigURL -Value 'http://${host}:${port}'"`
+          : `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name AutoConfigURL -Value ''"`;
 
         const updateInternetSettingsEnabled = enable
           ? `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' ProxyEnable -value 1"`

--- a/packages/daemon/src/platforms/windows/windows.ts
+++ b/packages/daemon/src/platforms/windows/windows.ts
@@ -74,7 +74,7 @@ export class WindowsPlatform implements Platform {
     return new Promise<void>(async (ok, err) => {
       try {
         const updateInternetSettingsProxy = enable
-          ? `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name AutoConfigURL -Value 'http://${host}:${port}'"`
+          ? `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name AutoConfigURL -Value 'http://${host}:${port}/proxy.pac'"`
           : `powershell -command "Set-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' -name AutoConfigURL -Value ''"`;
 
         const updateInternetSettingsEnabled = enable

--- a/packages/daemon/src/typings.ts
+++ b/packages/daemon/src/typings.ts
@@ -15,6 +15,10 @@ export interface EnableProxyMessage {
   type: MessageType.EnableProxy;
   host: string;
   port: number;
+  pac: {
+    host: string;
+    port: number;
+  };
   certificatePath: string;
   commonName: string;
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-server",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "Gateway server to enable trustless access to the Internet Computer.",
   "main": "built/main.js",
   "types": "built/main.d.ts",
@@ -51,8 +51,8 @@
   "dependencies": {
     "@dfinity/agent": "^0.15.6",
     "@dfinity/candid": "^0.15.6",
-    "@dfinity/http-proxy-core": "0.0.2-alpha",
-    "@dfinity/http-proxy-daemon": "0.0.2-alpha",
+    "@dfinity/http-proxy-core": "0.0.3-alpha",
+    "@dfinity/http-proxy-daemon": "0.0.3-alpha",
     "@dfinity/principal": "^0.15.6",
     "@dfinity/response-verification": "^0.2.1",
     "http-proxy": "^1.18.1",

--- a/packages/server/src/commons/configs.ts
+++ b/packages/server/src/commons/configs.ts
@@ -15,6 +15,10 @@ const environment: EnvironmentConfiguration = {
       organizationUnit: 'IC',
     },
   },
+  proxyConfigServer: {
+    host: '127.0.0.1',
+    port: 4049,
+  },
   netServer: {
     host: '127.0.0.1',
     port: 4050,

--- a/packages/server/src/commons/configs.ts
+++ b/packages/server/src/commons/configs.ts
@@ -3,7 +3,7 @@ import { EnvironmentConfiguration } from './typings';
 
 const environment: EnvironmentConfiguration = {
   platform: os.platform(),
-  userAgent: 'ICHttpProxy/0.0.2-alpha',
+  userAgent: 'ICHttpProxy/0.0.3-alpha',
   certificate: {
     storage: {
       folder: 'certs',

--- a/packages/server/src/commons/typings.ts
+++ b/packages/server/src/commons/typings.ts
@@ -10,10 +10,13 @@ export interface NetServerConfiguration {
   port: number;
 }
 
+export type ProxyConfigServerConfiguration = NetServerConfiguration;
+
 export interface EnvironmentConfiguration {
   userAgent: string;
   platform: string;
   certificate: CertificateConfiguration;
+  proxyConfigServer: ProxyConfigServerConfiguration;
   netServer: NetServerConfiguration;
   icpServer: ICPServerConfiguration;
 }

--- a/packages/server/src/servers/config/index.ts
+++ b/packages/server/src/servers/config/index.ts
@@ -1,0 +1,70 @@
+import { logger } from '@dfinity/http-proxy-core';
+import http from 'http';
+import { ProxyConfigOpts } from './typings';
+
+export class ProxyConfigurationServer {
+  private constructor(
+    private readonly server: http.Server,
+    private readonly opts: ProxyConfigOpts
+  ) {}
+
+  public static create(opts: ProxyConfigOpts): ProxyConfigurationServer {
+    const server = new ProxyConfigurationServer(http.createServer(), opts);
+    server.init();
+
+    return server;
+  }
+
+  private init(): void {
+    this.server.on('close', this.onClose.bind(this));
+    this.server.on('request', (req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain');
+      // use the proxy for all http and https requests,
+      // if the proxy server goes down fallback to a direct connection
+      res.end(
+        `function FindProxyForURL(url, host) {
+          if (url.startsWith("https:") || url.startsWith("http:")) {
+            return "PROXY ${this.opts.proxyServer.host}:${this.opts.proxyServer.port}; DIRECT";
+          }
+ 
+          return "DIRECT";
+        }`.trim()
+      );
+    });
+  }
+
+  public async shutdown(): Promise<void> {
+    logger.info('Shutting down proxy configuration server.');
+    return new Promise<void>((ok) => this.server.close(() => ok()));
+  }
+
+  public async start(): Promise<void> {
+    return new Promise<void>((ok, err) => {
+      const onListenError = (e: Error) => {
+        if ('code' in e && e.code === 'EADDRINUSE') {
+          this.server.close();
+        }
+
+        return err(e);
+      };
+
+      this.server.addListener('error', onListenError);
+
+      this.server.listen(this.opts.port, this.opts.host, () => {
+        this.server.removeListener('error', onListenError);
+        this.server.addListener('error', this.onError.bind(this));
+
+        ok();
+      });
+    });
+  }
+
+  private async onClose(): Promise<void> {
+    logger.info('Client disconnected');
+  }
+
+  private async onError(err: Error): Promise<void> {
+    logger.error(`NetProxy error: (${String(err)})`);
+  }
+}

--- a/packages/server/src/servers/config/index.ts
+++ b/packages/server/src/servers/config/index.ts
@@ -19,7 +19,7 @@ export class ProxyConfigurationServer {
     this.server.on('close', this.onClose.bind(this));
     this.server.on('request', (req, res) => {
       res.statusCode = 200;
-      res.setHeader('Content-Type', 'text/plain');
+      res.setHeader('Content-Type', 'application/x-ns-proxy-autoconfig');
       // use the proxy for all http and https requests,
       // if the proxy server goes down fallback to a direct connection
       res.end(

--- a/packages/server/src/servers/config/typings.ts
+++ b/packages/server/src/servers/config/typings.ts
@@ -1,0 +1,8 @@
+export interface ProxyConfigOpts {
+  host: string;
+  port: number;
+  proxyServer: {
+    host: string;
+    port: number;
+  };
+}

--- a/packages/server/src/servers/daemon/index.ts
+++ b/packages/server/src/servers/daemon/index.ts
@@ -51,6 +51,10 @@ export class DaemonProcess {
       commonName: opts.certificate.commonName,
       host: opts.proxy.host,
       port: opts.proxy.port,
+      pac: {
+        host: opts.pac.host,
+        port: opts.pac.port,
+      },
     };
 
     return this.ipcClient.sendMessage(message);

--- a/packages/server/src/servers/daemon/typings.ts
+++ b/packages/server/src/servers/daemon/typings.ts
@@ -7,4 +7,8 @@ export interface EnableProxyOptions {
     host: string;
     port: number;
   };
+  pac: {
+    host: string;
+    port: number;
+  };
 }

--- a/packages/server/src/servers/typings.ts
+++ b/packages/server/src/servers/typings.ts
@@ -2,10 +2,15 @@ import {
   CertificateConfiguration,
   IpcChannels,
 } from '@dfinity/http-proxy-core';
-import { ICPServerConfiguration, NetServerConfiguration } from '~src/commons';
+import {
+  ICPServerConfiguration,
+  NetServerConfiguration,
+  ProxyConfigServerConfiguration,
+} from '~src/commons';
 
 export interface ProxyServersOptions {
   certificate: CertificateConfiguration;
+  proxyConfigServer: ProxyConfigServerConfiguration;
   netServer: NetServerConfiguration;
   icpServer: ICPServerConfiguration;
   ipcChannels: IpcChannels;

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -31,6 +31,7 @@ process.on('unhandledRejection', (reason) => {
     logger.info('Preparing system requirements');
     servers = await ProxyServers.create({
       certificate: environment.certificate,
+      proxyConfigServer: environment.proxyConfigServer,
       icpServer: environment.icpServer,
       netServer: environment.netServer,
       ipcChannels: coreConfigs.ipcChannels,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/http-proxy-ui",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "Desktop interface to facilitate user interaction with the HTTP Proxy server.",
   "main": "built/main.js",
   "scripts": {
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/dfinity/http-proxy/tree/main/packages/ui#readme",
   "dependencies": {
-    "@dfinity/http-proxy-core": "0.0.2-alpha",
-    "@dfinity/http-proxy-server": "0.0.2-alpha"
+    "@dfinity/http-proxy-core": "0.0.3-alpha",
+    "@dfinity/http-proxy-server": "0.0.3-alpha"
   },
   "devDependencies": {
     "@types/node": "^18.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,7 +113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dfinity/http-proxy-core@0.0.2-alpha, @dfinity/http-proxy-core@workspace:packages/core":
+"@dfinity/http-proxy-core@0.0.3-alpha, @dfinity/http-proxy-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-core@workspace:packages/core"
   dependencies:
@@ -138,11 +138,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dfinity/http-proxy-daemon@0.0.2-alpha, @dfinity/http-proxy-daemon@workspace:packages/daemon":
+"@dfinity/http-proxy-daemon@0.0.3-alpha, @dfinity/http-proxy-daemon@workspace:packages/daemon":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-daemon@workspace:packages/daemon"
   dependencies:
-    "@dfinity/http-proxy-core": 0.0.2-alpha
+    "@dfinity/http-proxy-core": 0.0.3-alpha
     "@types/node": ^18.14.0
     "@types/node-forge": ^1.3.1
     "@types/pako": ^2.0.0
@@ -166,14 +166,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dfinity/http-proxy-server@0.0.2-alpha, @dfinity/http-proxy-server@workspace:packages/server":
+"@dfinity/http-proxy-server@0.0.3-alpha, @dfinity/http-proxy-server@workspace:packages/server":
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-server@workspace:packages/server"
   dependencies:
     "@dfinity/agent": ^0.15.6
     "@dfinity/candid": ^0.15.6
-    "@dfinity/http-proxy-core": 0.0.2-alpha
-    "@dfinity/http-proxy-daemon": 0.0.2-alpha
+    "@dfinity/http-proxy-core": 0.0.3-alpha
+    "@dfinity/http-proxy-daemon": 0.0.3-alpha
     "@dfinity/principal": ^0.15.6
     "@dfinity/response-verification": ^0.2.1
     "@types/isomorphic-fetch": ^0.0.36
@@ -202,8 +202,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dfinity/http-proxy-ui@workspace:packages/ui"
   dependencies:
-    "@dfinity/http-proxy-core": 0.0.2-alpha
-    "@dfinity/http-proxy-server": 0.0.2-alpha
+    "@dfinity/http-proxy-core": 0.0.3-alpha
+    "@dfinity/http-proxy-server": 0.0.3-alpha
     "@types/node": ^18.14.0
     "@typescript-eslint/eslint-plugin": ^5.54.1
     "@typescript-eslint/parser": ^5.54.1


### PR DESCRIPTION
This change alters how the proxy gets added to the system, it now uses a [PAC](https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file) file to decide if the proxy should be used and falls back to a direct connection if the proxy is not running. 

Moreover, on mac, it now only adds the configuration to the active network service name.

This change fixes two of the issues reported:

- Computer restarts or crashes and the user still has the proxy added to the settings even though its not running anymore
- Proxy configurations being added to unsupported and not active network interfaces that was causing the proxy to fail to start